### PR TITLE
require opencv-python-headless instead of opencv-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scipy
 pandas
 tqdm
 pyzmq
-opencv-python
+opencv-python-headless
 tifffile
 pyqt5
 pyqtgraph


### PR DESCRIPTION
When installing labcam as a depency (in our case for ibllib) opencv-python-headless installation gets overwritten by opencv-python. The issue is that opencv-python comes with Qt5 precompiled libraries that shadows the system Qt5 and causes issues. 

If headless is enough for your functionality, this fix would help a lot!
